### PR TITLE
Addeds retry functionality if "normal" get fails

### DIFF
--- a/azapi/azapi.py
+++ b/azapi/azapi.py
@@ -78,8 +78,15 @@ class AZlyrics(Requester):
 
         page = self.get(link, self.proxies)
         if page.status_code != 200:
-            print('Error',page.status_code)
-            return 1
+            if not self.search_engine:
+                print('Failed to find lyrics. Trying to get link from Google')
+                self.search_engine = 'google'
+                lyrics = self.getLyrics(url=url, ext=ext, save=save, path=path, sleep=sleep)
+                self.search_engine = ''
+                return lyrics
+            else:
+                print('Error',page.status_code)
+                return 1
 
         # Getting Basic metadata from azlyrics
         metadata = [elm.text for elm in htmlFindAll(page)('b')]
@@ -151,8 +158,16 @@ class AZlyrics(Requester):
         
         albums_page = self.get(link, self.proxies)
         if albums_page.status_code != 200:
-            print('Error 404!')
-            return {}
+            print('Error',albums_page.status_code)
+            if not self.search_engine:
+                print('Failed to find songs. Trying to get link from Google')
+                self.search_engine = 'google'
+                songs = self.getLyrics(sleep=sleep)
+                self.search_engine = ''
+                return songs
+            else:
+                print('Error',albums_page.status_code)
+                return {}
         
         # Store songs for later usage
         self.songs = parseSongs(albums_page)

--- a/azapi/azapi.py
+++ b/azapi/azapi.py
@@ -78,7 +78,7 @@ class AZlyrics(Requester):
 
         page = self.get(link, self.proxies)
         if page.status_code != 200:
-            print('Error 404!')
+            print('Error',page.status_code)
             return 1
 
         # Getting Basic metadata from azlyrics


### PR DESCRIPTION
If the user doesn't set the search engine and their request fails, I set the search engine to be "google" and recall the "getLyrics" method and store the output in a local variable. After that method runs, the search engine is set back to default and the output from that method that was stored in the local variable is return to the original caller. 