### PR TITLE
Return error if no metadata

### DIFF
--- a/azapi/azapi.py
+++ b/azapi/azapi.py
@@ -91,6 +91,11 @@ class AZlyrics(Requester):
         # Getting Basic metadata from azlyrics
         metadata = [elm.text for elm in htmlFindAll(page)('b')]
         
+        # if metadata is empty, then it's not a valid page
+        if not metadata:
+            print('Error', 'no metadata')
+            return 1
+        
         # v3.0.4: Update title and artist attributes with exact names
         self.artist = filtr(metadata[0][:-7], True)
         self.title = filtr(metadata[1][1:-1], True)


### PR DESCRIPTION
Currently if the server returns 200 but there is no page content, the script will fail with an invalid index. This change adds a simple validation to ensure the metadata exists.